### PR TITLE
Add a little more buffer to the deadline

### DIFF
--- a/src/assets/components/navigation.js
+++ b/src/assets/components/navigation.js
@@ -240,7 +240,7 @@ function Navigation(props) {
       && question.current.value.length <= 100
       && description.current.value.length <= 1000){
       const recentBlock = await web3.eth.getBlock('latest')
-      const deadline = recentBlock.timestamp + 605000
+      const deadline = recentBlock.timestamp + 610000
 
       proofErrors(question, description)
 


### PR DESCRIPTION
This is a temporary fix so that people don't run into issues if there is a gap between when they create and sign their transaction.

I also made a [PR in the contract repo](https://github.com/burnsignal/burnSignalContracts/pull/9) to remove the deadline validation from the contracts. I think this can be enforced on the frontend alone, if we want it at all.